### PR TITLE
docker & docker-compose & circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+version: 2
+jobs:
+  build_push:
+    environment:
+      IMAGE_NAME: detrous/museria
+    docker:
+      - image: docker:17.05.0-ce-git
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build image
+          command: |
+            docker build -t $IMAGE_NAME:$CIRCLE_SHA1 .
+            docker tag $IMAGE_NAME:$CIRCLE_SHA1 $IMAGE_NAME:latest
+      - run:
+          name: Push image
+          command: |
+            docker login -u $DOCKER_HUB_LOGIN -p "$DOCKER_HUB_PASSWORD"
+            docker push $IMAGE_NAME:$CIRCLE_SHA1
+            docker push $IMAGE_NAME:latest
+workflows:
+  version: 2
+  build_push_master:
+    jobs:
+      - build_push

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /node_modules
 /museria
+/museria-lib
+docker-compose.yml
 
 *.log
 *.bat

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:12-alpine3.9
+
+WORKDIR /usr/src/app
+
+RUN apk add --no-cache python3 make g++
+
+COPY . /usr/src/app
+
+RUN npm i
+
+CMD [ "npm", "start" ]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@
 This is a network configuration of the global decentralized storage for storing and receiving all the music we have on the planet. 
 It is based on [museria](https://github.com/ortexx/museria/).
 
+* [Running on machine](#Running-on-machine)
+* [Running in docker](#Running-in-docker)
+* [What is the idea](#What-is-the-idea)
+* [How it works](#How-it-works)
+* [How to get involved in this](#How-to-get-involved-in-this)
+* [Notes](#Notes)
+
+## Running on machine
+
 ```bash
 git clone https://github.com/ortexx/museria-global.git
 ```
@@ -10,6 +19,14 @@ git clone https://github.com/ortexx/museria-global.git
 ```bash
 npm i && npm start
 ```
+
+## Running in docker
+
+```bash
+cp docker-compose.example.yml docker-compose.yml
+docker-compose up
+```
+
 
 ## What is the idea
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+  museria:
+    image: detrous/museria
+    restart: on-failure
+    ports:
+      - 0.0.0.0:2079:2079
+    volumes:
+      - ./museria-lib:/usr/src/app/museria


### PR DESCRIPTION
Hi! I think it would be nice if users could easily run museria in an isolated environment

Added an image build for docker and an example of docker-compose.yml

There is also a config for auto build and push in CircleCi. Example of pipiline: https://app.circleci.com/jobs/github/Detrous/museria-global/13

For work you need
1) Docker hub account
2) CircleCi account
3) In the CircleCi project, set environment variables: DOCKER_HUB_LOGIN and DOCKER_HUB_PASSWORD
4) Replace the image name in .circle/config.yml and docker-compose.example.yml